### PR TITLE
feat: Auto Parse

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -31,6 +31,7 @@ Example usage: await boba.gongCha(browser)
 const dev = async () => {
   const browser = await puppeteer.launch({
     headless: isProduction,
+    defaultViewport: null,
   });
 
   const interpreter = repl.start();

--- a/src/sources/atm/dbs.js
+++ b/src/sources/atm/dbs.js
@@ -79,7 +79,7 @@ export default async function dbs(browser) {
             {
               id: 'atm',
               type: 'evaluatePage',
-              func: iteratee => {
+              evaluateFunc: iteratee => {
                 iteratee.scrollIntoView();
 
                 const address = iteratee.querySelector('.address');
@@ -101,7 +101,7 @@ export default async function dbs(browser) {
     },
     {
       type: 'mutateState',
-      func: state =>
+      mutateFunc: state =>
         Object.assign(state, {
           atms: state.atms.map(atm => atm.atmsChunk).reduce((a, b) => a.concat(b)),
         }),

--- a/src/sources/atm/dbs.js
+++ b/src/sources/atm/dbs.js
@@ -8,7 +8,7 @@ import autoParse from '../../util/auto-parse.js';
  * @returns {Promise<Boba[]>}
  */
 export default async function dbs(browser) {
-  const {atms} = await autoParse(browser, [
+  const atms = await autoParse(browser, [
     {
       type: 'navigate',
       url: 'https://www.dbs.com.sg/index/locator.page',
@@ -50,14 +50,11 @@ export default async function dbs(browser) {
       selector: '.address',
     },
     {
-      id: 'pageNumbers',
       type: 'elementsQuery',
       selector: '.navnum',
     },
     {
-      id: 'atms',
       type: 'iterator',
-      collectionId: 'pageNumbers',
       childSteps: [
         {
           type: 'elementClick',
@@ -67,21 +64,17 @@ export default async function dbs(browser) {
           selector: 'div.store',
         },
         {
-          id: 'stores',
           type: 'elementsQuery',
           selector: 'div.store',
           ignoreIteratee: true,
         },
         {
-          id: 'atmsChunk',
           type: 'iterator',
-          collectionId: 'stores',
           childSteps: [
             {
               type: 'elementScrollIntoView',
             },
             {
-              id: 'atm',
               type: 'elementQueryShape',
               queryShape: {
                 title: '.title',
@@ -93,17 +86,11 @@ export default async function dbs(browser) {
         },
       ],
     },
-    {
-      type: 'mutateState',
-      mutateFunc: state =>
-        Object.assign(state, {
-          atms: state.atms.map(atm => atm.atmsChunk).reduce((a, b) => a.concat(b)),
-        }),
-    },
   ]);
 
   const data = atms
-    .map(({atm}) =>
+    .flat()
+    .map(atm =>
       Object.assign(atm, {
         address: `${atm.address}\n${atm.postalCode || ''}`,
         openingHours: '24/7',

--- a/src/sources/atm/dbs.js
+++ b/src/sources/atm/dbs.js
@@ -70,6 +70,7 @@ export default async function dbs(browser) {
           id: 'stores',
           type: 'elementsQuery',
           selector: 'div.store',
+          ignoreIteratee: true,
         },
         {
           id: 'atmsChunk',
@@ -77,23 +78,27 @@ export default async function dbs(browser) {
           collectionId: 'stores',
           childSteps: [
             {
+              type: 'elementScrollIntoView',
+            },
+            {
               id: 'atm',
-              type: 'evaluatePage',
-              evaluateFunc: iteratee => {
-                iteratee.scrollIntoView();
-
-                const address = iteratee.querySelector('.address');
-                const postalCode = iteratee.querySelector('.postal_code');
-
-                return {
-                  title: iteratee.querySelector('.title').textContent.trim(),
-                  address: `${address ? address.textContent.trim() : ''}\n${
-                    postalCode ? iteratee.querySelector('.postal_code').textContent.trim() : ''
-                  }`,
-                  openingHours: '24/7',
-                  bank: 'DBS',
-                };
+              type: 'elementQueryShape',
+              queryShape: {
+                title: '.title',
+                address: '.address',
+                postalCode: '.postal_code',
               },
+            },
+            {
+              type: 'mutateState',
+              mutateFunc: state =>
+                Object.assign(state, {
+                  atm: Object.assign(state.atm, {
+                    address: `${state.atm.address}\n${state.atm.postalCode || ''}`,
+                    openingHours: '24/7',
+                    bank: 'DBS',
+                  }),
+                }),
             },
           ],
         }

--- a/src/sources/atm/dbs.js
+++ b/src/sources/atm/dbs.js
@@ -89,19 +89,8 @@ export default async function dbs(browser) {
                 postalCode: '.postal_code',
               },
             },
-            {
-              type: 'mutateState',
-              mutateFunc: state =>
-                Object.assign(state, {
-                  atm: Object.assign(state.atm, {
-                    address: `${state.atm.address}\n${state.atm.postalCode || ''}`,
-                    openingHours: '24/7',
-                    bank: 'DBS',
-                  }),
-                }),
-            },
           ],
-        }
+        },
       ],
     },
     {
@@ -113,5 +102,14 @@ export default async function dbs(browser) {
     },
   ]);
 
-  return Promise.map(atms, ({atm}) => autoLocation(atm), {concurrency: 1});
+  const data = atms
+    .map(({atm}) =>
+      Object.assign(atm, {
+        address: `${atm.address}\n${atm.postalCode || ''}`,
+        openingHours: '24/7',
+        bank: 'DBS',
+      })
+    )
+    .map(({postalCode, ...fields}) => ({...fields}));
+  return Promise.map(data, autoLocation, {concurrency: 1});
 }

--- a/src/sources/atm/dbs.js
+++ b/src/sources/atm/dbs.js
@@ -66,7 +66,7 @@ export default async function dbs(browser) {
         {
           type: 'elementsQuery',
           selector: 'div.store',
-          ignoreIteratee: true,
+          querySource: 'document',
         },
         {
           type: 'iterator',

--- a/src/sources/atm/dbs.js
+++ b/src/sources/atm/dbs.js
@@ -1,53 +1,112 @@
 import Promise from 'bluebird';
 import './model.js';
 import autoLocation from '../../util/auto-location.js';
+import autoParse from '../../util/auto-parse.js';
 
 /**
  * @param {import('puppeteer').Browser} browser
  * @returns {Promise<Boba[]>}
  */
 export default async function dbs(browser) {
-  const page = await browser.newPage();
-  await page.goto('https://www.dbs.com.sg/index/locator.page');
-  await page.waitForSelector('.jspContainer', {timeout: 5000});
-  await page.waitForSelector('#selectBranch', {timeout: 5000});
+  const {atms} = await autoParse(browser, [
+    {
+      type: 'navigate',
+      url: 'https://www.dbs.com.sg/index/locator.page',
+    },
+    {
+      type: 'elementWait',
+      selector: '.jspContainer',
+    },
+    {
+      type: 'elementWait',
+      selector: '#selectBranch',
+    },
+    {
+      type: 'elementClick',
+      selector: '#selectBranch',
+    },
+    {
+      type: 'elementWait',
+      selector: 'div.list-item[name="DBS"] .service-name',
+    },
+    {
+      type: 'elementClick',
+      selector: 'div.list-item[name="DBS"] .service-name',
+    },
+    {
+      type: 'elementClick',
+      selector: 'div.list-item[name="DL"] .service-name',
+    },
+    {
+      type: 'elementClick',
+      selector: 'div.list-item[name="ATM"] .service-name',
+    },
+    {
+      type: 'elementClick',
+      selector: '#listClose',
+    },
+    {
+      type: 'elementWait',
+      selector: '.address',
+    },
+    {
+      id: 'pageNumbers',
+      type: 'elementsQuery',
+      selector: '.navnum',
+    },
+    {
+      id: 'atms',
+      type: 'iterator',
+      collectionId: 'pageNumbers',
+      childSteps: [
+        {
+          type: 'elementClick',
+        },
+        {
+          type: 'elementWait',
+          selector: 'div.store',
+        },
+        {
+          id: 'stores',
+          type: 'elementsQuery',
+          selector: 'div.store',
+        },
+        {
+          id: 'atmsChunk',
+          type: 'iterator',
+          collectionId: 'stores',
+          childSteps: [
+            {
+              id: 'atm',
+              type: 'evaluatePage',
+              func: iteratee => {
+                iteratee.scrollIntoView();
 
-  // Filter to ATM
-  await page.evaluate(() => {
-    document.querySelector('#selectBranch').click();
+                const address = iteratee.querySelector('.address');
+                const postalCode = iteratee.querySelector('.postal_code');
 
-    document.querySelector('div[name="DBS"] .service-name').click();
-    document.querySelector('div[name="DL"] .service-name').click();
-    document.querySelector('div[name="ATM"] .service-name').click();
-    document.querySelector('#listClose').click();
-  });
+                return {
+                  title: iteratee.querySelector('.title').textContent.trim(),
+                  address: `${address ? address.textContent.trim() : ''}\n${
+                    postalCode ? iteratee.querySelector('.postal_code').textContent.trim() : ''
+                  }`,
+                  openingHours: '24/7',
+                  bank: 'DBS',
+                };
+              },
+            },
+          ],
+        }
+      ],
+    },
+    {
+      type: 'mutateState',
+      func: state =>
+        Object.assign(state, {
+          atms: state.atms.map(atm => atm.atmsChunk).reduce((a, b) => a.concat(b)),
+        }),
+    },
+  ]);
 
-  await page.waitForSelector('.address', {timeout: 5000});
-
-  const atms = await page.evaluate(async () => {
-    const pageNumbers = [...document.querySelectorAll('.navnum')];
-    return pageNumbers
-      .map(pageNumElement => {
-        pageNumElement.click();
-        return [...document.querySelectorAll('div.store')].map(item => {
-          item.scrollIntoView();
-
-          const address = item.querySelector('.address');
-          const postalCode = item.querySelector('.postal_code');
-
-          return {
-            title: item.querySelector('.title').textContent.trim(),
-            address: `${address ? address.textContent.trim() : ''}\n${
-              postalCode ? item.querySelector('.postal_code').textContent.trim() : ''
-            }`,
-            openingHours: '24/7',
-            bank: 'DBS',
-          };
-        });
-      })
-      .reduce((a, b) => a.concat(b)); // flatten 2D array
-  });
-
-  await page.close();
-  return Promise.map(atms, autoLocation, {concurrency: 1});
+  return Promise.map(atms, ({atm}) => autoLocation(atm), {concurrency: 1});
 }

--- a/src/sources/atm/ocbc.js
+++ b/src/sources/atm/ocbc.js
@@ -1,32 +1,61 @@
 import Promise from 'bluebird';
 import './model.js';
 import autoLocation from '../../util/auto-location.js';
+import autoParse from '../../util/auto-parse.js';
 
 /**
  * @param {import('puppeteer').Browser} browser
  * @returns {Promise<Boba[]>}
  */
 export default async function ocbc(browser) {
-  const page = await browser.newPage();
-  await page.goto('https://www.ocbc.com/personal-banking/locate-us.html');
-  await page.waitForSelector('#tab2', {timeout: 5000});
-  const atms = await page.evaluate(() => {
-    const listViewButton = document.querySelector('#tab2');
-    listViewButton.scrollIntoView();
-    listViewButton.click();
-    const items = [...document.querySelectorAll('.address-column')];
+  const {atms} = await autoParse(browser, [
+    {
+      type: 'navigate',
+      url: 'https://www.ocbc.com/personal-banking/locate-us.html',
+    },
+    {
+      type: 'elementWait',
+      selector: '#tab2',
+    },
+    {
+      type: 'elementScrollIntoView',
+      selector: '#tab2',
+    },
+    {
+      type: 'elementClick',
+      selector: '#tab2',
+    },
+    {
+      id: 'addressColumns',
+      type: 'elementsQuery',
+      selector: '.address-column',
+    },
+    {
+      id: 'atms',
+      type: 'iterator',
+      collectionId: 'addressColumns',
+      childSteps: [
+        {
+          id: 'atm',
+          type: 'elementQueryShape',
+          queryShape: {
+            title: 'font',
+            address: ['font', location => location.match(/(\d{6})/)[0]],
+          },
+        },
+        {
+          type: 'mutateState',
+          func: state =>
+            Object.assign(state, {
+              atm: Object.assign(state.atm, {
+                openingHours: '24/7',
+                bank: 'OCBC',
+              }),
+            }),
+        },
+      ],
+    },
+  ]);
 
-    return items.map(item => {
-      const location = item.querySelector('font').textContent.trim();
-      return {
-        title: location,
-        address: location.match(/(\d{6})/)[0],
-        openingHours: '24/7',
-        bank: 'OCBC',
-      };
-    });
-  });
-
-  await page.close();
-  return Promise.map(atms, autoLocation, {concurrency: 1});
+  return Promise.map(atms, ({atm}) => autoLocation(atm), {concurrency: 1});
 }

--- a/src/sources/atm/ocbc.js
+++ b/src/sources/atm/ocbc.js
@@ -43,19 +43,15 @@ export default async function ocbc(browser) {
             address: ['font', location => location.match(/(\d{6})/)[0]],
           },
         },
-        {
-          type: 'mutateState',
-          mutateFunc: state =>
-            Object.assign(state, {
-              atm: Object.assign(state.atm, {
-                openingHours: '24/7',
-                bank: 'OCBC',
-              }),
-            }),
-        },
       ],
     },
   ]);
 
-  return Promise.map(atms, ({atm}) => autoLocation(atm), {concurrency: 1});
+  const data = atms.map(({atm}) =>
+    Object.assign(atm, {
+      openingHours: '24/7',
+      bank: 'OCBC',
+    })
+  );
+  return Promise.map(data, autoLocation, {concurrency: 1});
 }

--- a/src/sources/atm/ocbc.js
+++ b/src/sources/atm/ocbc.js
@@ -8,7 +8,7 @@ import autoParse from '../../util/auto-parse.js';
  * @returns {Promise<Boba[]>}
  */
 export default async function ocbc(browser) {
-  const {atms} = await autoParse(browser, [
+  const atms = await autoParse(browser, [
     {
       type: 'navigate',
       url: 'https://www.ocbc.com/personal-banking/locate-us.html',
@@ -26,17 +26,13 @@ export default async function ocbc(browser) {
       selector: '#tab2',
     },
     {
-      id: 'addressColumns',
       type: 'elementsQuery',
       selector: '.address-column',
     },
     {
-      id: 'atms',
       type: 'iterator',
-      collectionId: 'addressColumns',
       childSteps: [
         {
-          id: 'atm',
           type: 'elementQueryShape',
           queryShape: {
             title: 'font',
@@ -47,7 +43,7 @@ export default async function ocbc(browser) {
     },
   ]);
 
-  const data = atms.map(({atm}) =>
+  const data = atms.map(atm =>
     Object.assign(atm, {
       openingHours: '24/7',
       bank: 'OCBC',

--- a/src/sources/atm/ocbc.js
+++ b/src/sources/atm/ocbc.js
@@ -45,7 +45,7 @@ export default async function ocbc(browser) {
         },
         {
           type: 'mutateState',
-          func: state =>
+          mutateFunc: state =>
             Object.assign(state, {
               atm: Object.assign(state.atm, {
                 openingHours: '24/7',

--- a/src/sources/boba/blackball.js
+++ b/src/sources/boba/blackball.js
@@ -8,23 +8,19 @@ import autoParse from '../../util/auto-parse.js';
  * @returns {Promise<Boba[]>}
  */
 export default async function blackball(browser) {
-  const {outlets} = await autoParse(browser, [
+  const outlets = await autoParse(browser, [
     {
       type: 'navigate',
       url: 'http://blackball.com.sg/index.php/outlet-location/',
     },
     {
-      id: 'locations',
       type: 'elementsQuery',
       selector: '.location',
     },
     {
-      id: 'outlets',
       type: 'iterator',
-      collectionId: 'locations',
       childSteps: [
         {
-          id: 'outlet',
           type: 'elementQueryShape',
           queryShape: {
             title: '.location-title-pro',
@@ -36,6 +32,6 @@ export default async function blackball(browser) {
     },
   ]);
 
-  const data = outlets.map(({outlet}) => Object.assign(outlet, {chain: 'Blackball'}));
+  const data = outlets.map(outlet => Object.assign(outlet, {chain: 'Blackball'}));
   return Promise.map(data, autoLocation, {concurrency: 1});
 }

--- a/src/sources/boba/blackball.js
+++ b/src/sources/boba/blackball.js
@@ -1,24 +1,39 @@
 import Promise from 'bluebird';
 import './model.js';
 import autoLocation from '../../util/auto-location.js';
+import autoParse from '../../util/auto-parse.js';
 
 /**
  * @param {import('puppeteer').Browser} browser
  * @returns {Promise<Boba[]>}
  */
 export default async function blackball(browser) {
-  const page = await browser.newPage();
-  await page.goto('http://blackball.com.sg/index.php/outlet-location/');
-  const outlets = await page.evaluate(() => {
-    const items = [...document.querySelectorAll('.location')];
-
-    return items.map(item => ({
-      title: item.querySelector('.location-title-pro').textContent.trim(),
-      address: item.querySelector('.location-address-pro').textContent.trim(),
-      openingHours: item.querySelector('.location-time-pro').textContent.trim(),
-      chain: 'BlackBall',
-    }));
-  });
-  await page.close();
-  return Promise.map(outlets, autoLocation, {concurrency: 1});
+  const {outlets} = await autoParse(browser, [
+    {
+      type: 'navigate',
+      url: 'http://blackball.com.sg/index.php/outlet-location/',
+    },
+    {
+      id: 'locations',
+      type: 'elementsQuery',
+      selector: '.location',
+    },
+    {
+      id: 'outlets',
+      type: 'iterator',
+      collectionId: 'locations',
+      childSteps: [
+        {
+          id: 'outlet',
+          type: 'evaluatePage',
+          func: location => ({
+            title: location.querySelector('.location-title-pro').textContent.trim(),
+            address: location.querySelector('.location-address-pro').textContent.trim(),
+            openingHours: location.querySelector('.location-time-pro').textContent.trim(),
+          }),
+        },
+      ],
+    },
+  ]);
+  return Promise.map(outlets, ({outlet}) => autoLocation(outlet), {concurrency: 1});
 }

--- a/src/sources/boba/blackball.js
+++ b/src/sources/boba/blackball.js
@@ -35,5 +35,7 @@ export default async function blackball(browser) {
       ],
     },
   ]);
-  return Promise.map(outlets, ({outlet}) => autoLocation(outlet), {concurrency: 1});
+
+  const data = outlets.map(({outlet}) => Object.assign(outlet, {chain: 'Blackball'}));
+  return Promise.map(data, autoLocation, {concurrency: 1});
 }

--- a/src/sources/boba/blackball.js
+++ b/src/sources/boba/blackball.js
@@ -25,12 +25,12 @@ export default async function blackball(browser) {
       childSteps: [
         {
           id: 'outlet',
-          type: 'evaluatePage',
-          evaluateFunc: location => ({
-            title: location.querySelector('.location-title-pro').textContent.trim(),
-            address: location.querySelector('.location-address-pro').textContent.trim(),
-            openingHours: location.querySelector('.location-time-pro').textContent.trim(),
-          }),
+          type: 'elementQueryShape',
+          queryShape: {
+            title: '.location-title-pro',
+            address: '.location-address-pro',
+            openingHours: '.location-time-pro',
+          },
         },
       ],
     },

--- a/src/sources/boba/blackball.js
+++ b/src/sources/boba/blackball.js
@@ -26,7 +26,7 @@ export default async function blackball(browser) {
         {
           id: 'outlet',
           type: 'evaluatePage',
-          func: location => ({
+          evaluateFunc: location => ({
             title: location.querySelector('.location-title-pro').textContent.trim(),
             address: location.querySelector('.location-address-pro').textContent.trim(),
             openingHours: location.querySelector('.location-time-pro').textContent.trim(),

--- a/src/sources/boba/each-a-cup.js
+++ b/src/sources/boba/each-a-cup.js
@@ -12,43 +12,43 @@ const REGIONS = ['Central', 'North', 'West', 'East'];
  * @returns {Promise<Boba[]>}
  */
 export default async function eachACup(browser) {
-  const outlets = await autoParse(browser, [
-    {
-      type: 'mutateResult',
-      mutateFunc: () => REGIONS,
-    },
-    {
-      type: 'iterator',
-      childSteps: [
-        {
-          type: 'navigate',
-          url: (_, region) => `http://www.each-a-cup.com/home/outlets/${region}`,
-        },
-        {
-          type: 'elementWait',
-          selector: '.service-item',
-        },
-        {
-          type: 'elementsQuery',
-          querySource: 'document',
-          selector: '.service-item',
-        },
-        {
-          type: 'iterator',
-          childSteps: [
-            {
-              type: 'elementQueryShape',
-              queryShape: {
-                title: 'h3',
-                address: 'p:nth-child(2)',
-                phone: 'p:nth-child(3)',
+  const outlets = await autoParse(
+    browser,
+    [
+      {
+        type: 'iterator',
+        childSteps: [
+          {
+            type: 'navigate',
+            url: (_, region) => `http://www.each-a-cup.com/home/outlets/${region}`,
+          },
+          {
+            type: 'elementWait',
+            selector: '.service-item',
+          },
+          {
+            type: 'elementsQuery',
+            querySource: 'document',
+            selector: '.service-item',
+          },
+          {
+            type: 'iterator',
+            childSteps: [
+              {
+                type: 'elementQueryShape',
+                queryShape: {
+                  title: 'h3',
+                  address: 'p:nth-child(2)',
+                  phone: 'p:nth-child(3)',
+                },
               },
-            },
-          ],
-        },
-      ],
-    },
-  ]);
+            ],
+          },
+        ],
+      },
+    ],
+    REGIONS
+  );
 
   const data = outlets.flat().map(outlet => Object.assign(outlet, {chain: 'Each-A-Cup'}));
   return Promise.map(data, autoLocation, {concurrency: 1});

--- a/src/sources/boba/each-a-cup.js
+++ b/src/sources/boba/each-a-cup.js
@@ -30,7 +30,7 @@ export default async function eachACup(browser) {
         },
         {
           type: 'elementsQuery',
-          ignoreIteratee: true,
+          querySource: 'document',
           selector: '.service-item',
         },
         {

--- a/src/sources/boba/each-a-cup.js
+++ b/src/sources/boba/each-a-cup.js
@@ -3,35 +3,53 @@
 import Promise from 'bluebird';
 import './model.js';
 import autoLocation from '../../util/auto-location.js';
+import autoParse from '../../util/auto-parse.js';
 
 const REGIONS = ['Central', 'North', 'West', 'East'];
-
-const TITLE_REGEX = new RegExp(/\(([\w\s]*)\)/);
 
 /**
  * @param {import('puppeteer').Browser} browser
  * @returns {Promise<Boba[]>}
  */
 export default async function eachACup(browser) {
-  const page = await browser.newPage();
-  const outlets = [];
-  for (const region of REGIONS) {
-    await page.goto(`http://www.each-a-cup.com/home/outlets/${region}`);
-    await page.waitForSelector('.service-item', {timeout: 5000});
+  const outlets = await autoParse(browser, [
+    {
+      type: 'mutateResult',
+      mutateFunc: () => REGIONS,
+    },
+    {
+      type: 'iterator',
+      childSteps: [
+        {
+          type: 'navigate',
+          url: (_, region) => `http://www.each-a-cup.com/home/outlets/${region}`,
+        },
+        {
+          type: 'elementWait',
+          selector: '.service-item',
+        },
+        {
+          type: 'elementsQuery',
+          ignoreIteratee: true,
+          selector: '.service-item',
+        },
+        {
+          type: 'iterator',
+          childSteps: [
+            {
+              type: 'elementQueryShape',
+              queryShape: {
+                title: 'h3',
+                address: 'p:nth-child(2)',
+                phone: 'p:nth-child(3)',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ]);
 
-    const results = await page.evaluate(() => {
-      const items = [...document.querySelectorAll('.service-item')];
-
-      return items.map(item => ({
-        title: item.querySelector('h3').textContent.trim(),
-        address: item.querySelector('p:nth-child(2)').textContent.trim(),
-        phone: item.querySelector('p:nth-child(3)').textContent.trim(),
-        chain: 'Each-A-Cup',
-      }));
-    });
-    outlets.push(...results);
-  }
-
-  await page.close();
-  return Promise.map(outlets, autoLocation, {concurrency: 1});
+  const data = outlets.flat().map(outlet => Object.assign(outlet, {chain: 'Each-A-Cup'}));
+  return Promise.map(data, autoLocation, {concurrency: 1});
 }

--- a/src/sources/boba/gong-cha.js
+++ b/src/sources/boba/gong-cha.js
@@ -8,7 +8,7 @@ import autoParse from '../../util/auto-parse.js';
  * @returns {Promise<Boba[]>}
  */
 export default async function gongCha(browser) {
-  const {outlets} = await autoParse(browser, [
+  const outlets = await autoParse(browser, [
     {
       type: 'navigate',
       url: 'http://www.gong-cha-sg.com/stores/',
@@ -19,17 +19,13 @@ export default async function gongCha(browser) {
       timeout: 15000,
     },
     {
-      id: 'items',
       type: 'elementsQuery',
       selector: '.item',
     },
     {
-      id: 'outlets',
       type: 'iterator',
-      collectionId: 'items',
       childSteps: [
         {
-          id: 'outlet',
           type: 'elementQueryShape',
           queryShape: {
             title: '.p-title',
@@ -41,7 +37,7 @@ export default async function gongCha(browser) {
     },
   ]);
 
-  const data = outlets.map(({outlet}) =>
+  const data = outlets.map(outlet =>
     Object.assign(outlet, {
       chain: 'Gong Cha',
     })

--- a/src/sources/boba/koi.js
+++ b/src/sources/boba/koi.js
@@ -33,18 +33,11 @@ export default async function koi(browser) {
             openingHours: '.txt',
           },
         },
-        {
-          type: 'mutateState',
-          mutateFunc: state =>
-            Object.assign(state, {
-              outlet: Object.assign(state.outlet, {
-                chain: 'KOI',
-              }),
-            }),
-        },
       ],
     },
   ]);
 
-  return Promise.map(outlets, ({outlet}) => autoLocation(outlet), {concurrency: 1});
+  const data = outlets.map(({outlet}) => Object.assign(outlet, {chain: 'KOI'}));
+
+  return Promise.map(data, autoLocation, {concurrency: 1});
 }

--- a/src/sources/boba/koi.js
+++ b/src/sources/boba/koi.js
@@ -8,23 +8,19 @@ import autoParse from '../../util/auto-parse.js';
  * @returns {Promise<Boba[]>}
  */
 export default async function koi(browser) {
-  const {outlets} = await autoParse(browser, [
+  const outlets = await autoParse(browser, [
     {
       type: 'navigate',
       url: 'https://www.koithe.com/en/global/koi-singapore',
     },
     {
-      id: 'items',
       type: 'elementsQuery',
       selector: '.global-wrap .item',
     },
     {
-      id: 'outlets',
       type: 'iterator',
-      collectionId: 'items',
       childSteps: [
         {
-          id: 'outlet',
           type: 'elementQueryShape',
           queryShape: {
             title: '.titlebox',
@@ -37,7 +33,7 @@ export default async function koi(browser) {
     },
   ]);
 
-  const data = outlets.map(({outlet}) => Object.assign(outlet, {chain: 'KOI'}));
+  const data = outlets.map(outlet => Object.assign(outlet, {chain: 'KOI'}));
 
   return Promise.map(data, autoLocation, {concurrency: 1});
 }

--- a/src/sources/boba/koi.js
+++ b/src/sources/boba/koi.js
@@ -1,26 +1,50 @@
 import Promise from 'bluebird';
 import './model.js';
 import autoLocation from '../../util/auto-location.js';
+import autoParse from '../../util/auto-parse.js';
 
 /**
  * @param {import('puppeteer').Browser} browser
  * @returns {Promise<Boba[]>}
  */
 export default async function koi(browser) {
-  const page = await browser.newPage();
-  await page.goto('https://www.koithe.com/en/global/koi-singapore');
-  const outlets = await page.evaluate(() => {
-    const items = [...document.querySelectorAll('.global-wrap .item')];
+  const {outlets} = await autoParse(browser, [
+    {
+      type: 'navigate',
+      url: 'https://www.koithe.com/en/global/koi-singapore',
+    },
+    {
+      id: 'items',
+      type: 'elementsQuery',
+      selector: '.global-wrap .item',
+    },
+    {
+      id: 'outlets',
+      type: 'iterator',
+      collectionId: 'items',
+      childSteps: [
+        {
+          id: 'outlet',
+          type: 'elementQueryShape',
+          queryShape: {
+            title: '.titlebox',
+            address: '.txt a',
+            phone: '.titlebox',
+            openingHours: '.txt',
+          },
+        },
+        {
+          type: 'mutateState',
+          mutateFunc: state =>
+            Object.assign(state, {
+              outlet: Object.assign(state.outlet, {
+                chain: 'KOI',
+              }),
+            }),
+        },
+      ],
+    },
+  ]);
 
-    return items.map(item => ({
-      title: item.querySelector('.titlebox').textContent.trim(),
-      address: item.querySelector('.txt a').textContent.trim(),
-      phone: item.querySelector('.titlebox').textContent.trim(),
-      openingHours: item.querySelector('.txt').textContent.trim(),
-      chain: 'Koi',
-    }));
-  });
-
-  await page.close();
-  return Promise.map(outlets, autoLocation, {concurrency: 1});
+  return Promise.map(outlets, ({outlet}) => autoLocation(outlet), {concurrency: 1});
 }

--- a/src/sources/boba/sharetea.js
+++ b/src/sources/boba/sharetea.js
@@ -40,7 +40,7 @@ export default async function sharetea(browser) {
         },
         {
           type: 'elementQueryShape',
-          ignoreIteratee: true,
+          querySource: 'document',
           queryShape: {
             title: '.wpsl-locations-details > span:first-child',
             address: '.wpsl-location-address',

--- a/src/sources/boba/sharetea.js
+++ b/src/sources/boba/sharetea.js
@@ -1,53 +1,56 @@
-/* eslint-disable no-await-in-loop */
-/* eslint-disable no-restricted-syntax */
 import Promise from 'bluebird';
 import './model.js';
 import autoLocation from '../../util/auto-location.js';
+import autoParse from '../../util/auto-parse.js';
 
 /**
  * @param {import('puppeteer').Browser} browser
  * @returns {Promise<Boba[]>}
  */
 export default async function sharetea(browser) {
-  const page = await browser.newPage();
-  await page.goto('http://www.1992sharetea.com/locations');
-  await page.waitForSelector('.fr-box', {timeout: 5000});
+  const outlets = await autoParse(browser, [
+    {
+      type: 'navigate',
+      url: 'http://www.1992sharetea.com/locations',
+    },
+    {
+      type: 'elementWait',
+      selector: '.fr-box',
+    },
+    {
+      type: 'elementsQuery',
+      selector: `//*[contains(text(), 'Singapore')]/../../p/a`,
+      isXPathSelector: true,
+    },
+    {
+      type: 'iterator',
+      childSteps: [
+        {
+          type: 'evaluatePage',
+          evaluateFunc: (_, elem) => elem.getAttribute('href'),
+        },
+      ],
+    },
+    {
+      type: 'iterator',
+      childSteps: [
+        {
+          type: 'navigate',
+          url: (_, href) => href,
+        },
+        {
+          type: 'elementQueryShape',
+          ignoreIteratee: true,
+          queryShape: {
+            title: '.wpsl-locations-details > span:first-child',
+            address: '.wpsl-location-address',
+            openingHours: '.wpsl-opening-hours',
+          },
+        },
+      ],
+    },
+  ]);
 
-  const urls = await page.evaluate(() => {
-    const items = [];
-    const xPathResult = document.evaluate(
-      "//*[contains(text(), 'Singapore')]/../../p/a",
-      document,
-      null,
-      XPathResult.ORDERED_NODE_ITERATOR_TYPE,
-      null
-    );
-    let node = xPathResult.iterateNext();
-    while (node) {
-      items.push(node);
-      node = xPathResult.iterateNext();
-    }
-
-    return items
-      .filter(item => item.offsetHeight !== 0) // Filter out weird hidden outlet
-      .map(item => item.getAttribute('href'));
-  });
-
-  const items = [];
-
-  for (const url of urls) {
-    await page.goto(url);
-    const outlet = await page.evaluate(() => ({
-      title: document
-        .querySelector('.wpsl-locations-details > span:first-child')
-        .textContent.trim(),
-      address: document.querySelector('.wpsl-location-address').textContent.trim(),
-      openingHours: document.querySelector('.wpsl-opening-hours').textContent.trim(),
-      chain: 'ShareTea',
-    }));
-    items.push(outlet);
-  }
-
-  await page.close();
-  return Promise.map(items, autoLocation, {concurrency: 1});
+  const data = outlets.map(outlet => Object.assign(outlet, {chain: 'ShareTea'}));
+  return Promise.map(data, autoLocation, {concurrency: 1});
 }

--- a/src/sources/boba/sharetea.js
+++ b/src/sources/boba/sharetea.js
@@ -20,7 +20,7 @@ export default async function sharetea(browser) {
     {
       type: 'elementsQuery',
       selector: `//*[contains(text(), 'Singapore')]/../../p/a`,
-      isXPathSelector: true,
+      selectorType: 'xpath',
     },
     {
       type: 'iterator',

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -18,7 +18,7 @@
 
 /**
  * @typedef Step
- * @property {('navigate'|'elementClick'|'elementWait'|'elementsQuery'|'iterator'|'evaluatePage'|'mutateState')} type
+ * @property {('navigate'|'elementClick'|'elementWait'|'elementsQuery'|'elementScrollIntoView'|'iterator'|'evaluatePage'|'mutateState')} type
  * @property {string|IteratorTargetFunction} selector DOM selector
  *
  * (optional id)
@@ -109,6 +109,15 @@ export default async function autoParse(browser, steps) {
         break;
       case 'elementWait':
         await page.waitForSelector(selector, {visible: true, timeout});
+        break;
+      case 'elementScrollIntoView':
+        await page.evaluate(arg => {
+          if (arg instanceof HTMLElement) {
+            arg.scrollIntoView();
+          } else {
+            document.querySelector(arg).scrollIntoView();
+          }
+        }, selector || iteratee);
         break;
       case 'elementsQuery':
         return Object.assign(state, {

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -82,7 +82,7 @@ export default async function autoParse(browser, steps) {
       mutateFunc,
       url,
       queryShape,
-      querySource,
+      querySource = 'iteratee', // will default to document if no iteratee
     } = step;
 
     const iteratorResults = [];

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -85,7 +85,7 @@ export default async function autoParse(browser, steps) {
     } = step;
 
     const iteratorResults = [];
-    let elementQueryShapeResult = {};
+    const elementQueryShapeResult = {};
 
     switch (type) {
       case 'navigate':

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -134,16 +134,20 @@ export default async function autoParse(browser, steps) {
             case isString(value):
               elementQueryShapeResult[key] = await page.evaluate(
                 (elem, sel) =>
-                  elem.querySelector(sel) ? elem.querySelector(sel).textContent.trim() : null,
-                iteratee || page,
+                  (elem || document).querySelector(sel)
+                    ? (elem || document).querySelector(sel).textContent.trim()
+                    : null,
+                !ignoreIteratee && iteratee,
                 value
               );
               break;
             case Array.isArray(value):
               elementQueryShapeResult[key] = await page.evaluate(
                 (elem, sel) =>
-                  elem.querySelector(sel) ? elem.querySelector(sel).textContent.trim() : null,
-                iteratee || page,
+                  (elem || document).querySelector(sel)
+                    ? (elem || document).querySelector(sel).textContent.trim()
+                    : null,
+                !ignoreIteratee && iteratee,
                 value[0]
               );
               elementQueryShapeResult[key] = value[1](elementQueryShapeResult[key]);

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -155,7 +155,7 @@ export default async function autoParse(browser, steps) {
         }
         return elementQueryShapeResult;
       case 'evaluatePage':
-        return page.evaluate(evaluateFunc, iteratee);
+        return page.evaluate(evaluateFunc, prevResult, iteratee);
       case 'iterator':
         if (!prevResult) {
           throw new Error('prevResult is not a collection that is iterable:', prevResult);

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -62,9 +62,10 @@ const generateRandomString = () =>
  * @async
  * @param {import('puppeteer').Browser} browser
  * @param {(Step)[]} steps
+ * @param {object} initialResult an initial result to pass to the first step
  * @returns {object[]}
  */
-export default async function autoParse(browser, steps) {
+export default async function autoParse(browser, steps, initialResult = null) {
   const page = await browser.newPage();
 
   /**
@@ -184,7 +185,7 @@ export default async function autoParse(browser, steps) {
     return null;
   }
 
-  let result = null;
+  let result = initialResult;
 
   for (const step of steps) {
     try {

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -1,17 +1,18 @@
 /**
- * @typedef {Object<string, object>} State
- * Object that contains state for the entire steps run
- */
-
-/**
  * @callback QueryShapeProcessFunction
  * @param {string}
  */
 
 /**
  * @callback EvaluateFunction
- * @param {State} state the current state of the object to be returned. contains state from previous steps.
- * @param {object} [evaluateArg] optional argument. within an iterable this is the collection item
+ * @param {object} prevResult result of the previous step
+ * @param {object} [iteratee] iteratee (if running within a parent step)
+ */
+
+/**
+ * @callback URLEvaluateFunction
+ * @param {object} prevResult result of the previous step
+ * @param {object} [iteratee] iteratee (if running within a parent step)
  * @returns {string}
  */
 
@@ -25,7 +26,7 @@
  * @property {number} [timeout] timeout for wait
  *
  * navigate
- * @property {string|EvaluateFunction} [url]
+ * @property {string|URLEvaluateFunction} [url]
  *
  * evaluate
  * @property {EvaluateFunction} [evaluateFunc]

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -1,6 +1,7 @@
 /**
  * @callback QueryShapeProcessFunction
- * @param {string}
+ * @param {string} queriedResult
+ * @returns {string}
  */
 
 /**
@@ -19,29 +20,31 @@
 /**
  * @typedef Step
  * @property {('navigate'|'elementClick'|'elementWait'|'elementsQuery'|'elementQueryShape'|'elementScrollIntoView'|'iterator'|'evaluatePage'|'mutateResult')} type
+ *
+ * elementClick, elementWait, elementsQuery, elementScrollIntoView
  * @property {string} selector DOM selector
  * @property {('css'|'xpath')} selectorType type of the selector
  *
  * elementWait
- * @property {number} [timeout] timeout for wait
+ * @property {number} [timeout=5000] timeout for elementWait
  *
  * navigate
- * @property {string|URLEvaluateFunction} [url]
+ * @property {string|URLEvaluateFunction} url url to navigate to
  *
  * evaluate
- * @property {EvaluateFunction} [evaluateFunc]
+ * @property {EvaluateFunction} [evaluateFunc] function to be evaluated
  *
  * mutateResult
- * @property {EvaluateFunction} [mutateFunc]
+ * @property {EvaluateFunction} [mutateFunc] function to be evaluated. this function is expected to mutate the result from the last step
  *
  * iterator
- * @property {Step[]} [childSteps]
+ * @property {Step[]} [childSteps] steps to run for each iteratee
  *
  * elementsQuery
  * @property {('iteratee'|'document')} [querySource] whether to ignore the iteratee to query
  *
  * elementQueryShape
- * @property {Object.<string, string>|[Object.<string, string>, QueryShapeProcessFunction]} [queryShape]
+ * @property {Object.<string, string|[string, QueryShapeProcessFunction]>} [queryShape] element shape to return
  */
 
 const isString = obj => typeof obj === 'string';

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -18,7 +18,7 @@
 /**
  * @typedef Step
  * @property {('navigate'|'elementClick'|'elementWait'|'elementsQuery'|'elementQueryShape'|'elementScrollIntoView'|'iterator'|'evaluatePage'|'mutateResult')} type
- * @property {string|IteratorTargetFunction} selector DOM selector
+ * @property {string} selector DOM selector
  * @property {('css'|'xpath')} selectorType type of the selector
  *
  * elementWait

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -30,7 +30,10 @@
  * @property {string|EvaluateFunction} [url]
  *
  * evaluate
- * @property {EvaluateFunction} [func]
+ * @property {EvaluateFunction} [evaluateFunc]
+ *
+ * mutateState
+ * @property {EvaluateFunction} [mutateFunc]
  *
  * iterator
  * @property {Step[]} [childSteps]
@@ -79,7 +82,8 @@ export default async function autoParse(browser, steps) {
       timeout = 5000,
       childSteps,
       collectionId,
-      func,
+      evaluateFunc,
+      mutateFunc,
       url,
       queryShape,
     } = step;
@@ -153,7 +157,7 @@ export default async function autoParse(browser, steps) {
         });
       case 'evaluatePage':
         return Object.assign(state, {
-          [id]: await page.evaluate(func, iteratee),
+          [id]: await page.evaluate(evaluateFunc, iteratee),
         });
       case 'iterator':
         if (!(collectionId in state)) {
@@ -172,7 +176,7 @@ export default async function autoParse(browser, steps) {
           [id]: iteratorResults,
         });
       case 'mutateState':
-        return Object.assign(state, await func(state));
+        return Object.assign(state, await mutateFunc(state));
       default:
         console.error('Unknown step type', type);
         break;

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -35,7 +35,6 @@
  *
  * iterator
  * @property {Step[]} [childSteps]
- * @property {Step} [parent] parent step
  *
  * elementsQuery
  * @property {('iteratee'|'document')} [querySource] whether to ignore the iteratee to query

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -1,0 +1,155 @@
+/**
+ * @typedef {Object<string, object>} State
+ * Object that contains state for the entire steps run
+ */
+
+/**
+ * @callback ChildShapeKeyFunction
+ * @param {HTMLElement} element
+ * @returns undefined
+ */
+
+/**
+ * @callback EvaluateFunction
+ * @param {State} state the current state of the object to be returned. contains state from previous steps.
+ * @param {object} [evaluateArg] optional argument. within an iterable this is the collection item
+ * @returns {string}
+ */
+
+/**
+ * @typedef Step
+ * @property {('navigate'|'elementClick'|'elementWait'|'elementsQuery'|'iterator'|'evaluatePage'|'mutateState')} type
+ * @property {string|IteratorTargetFunction} selector DOM selector
+ *
+ * (optional id)
+ * @property {string} [id] id string used to store data in the returned object
+ *
+ * elementWait
+ * @property {number} [timeout] timeout for wait
+ *
+ * navigate
+ * @property {string|EvaluateFunction} [url]
+ *
+ * evaluate
+ * @property {EvaluateFunction} [func]
+ *
+ * iterator
+ * @property {Step[]} [childSteps]
+ * @property {Step} [parent] parent step
+ * @property {string} collectionId key to an collection in the state object
+ *
+ * elementQuery
+ * @ property {Object.<string, string|ChildShapeKeyFunction|Promise<HTMLElement>>} [childShape]
+ */
+
+const isString = obj => typeof obj === 'string';
+const isFunction = obj => obj instanceof Function;
+const isAsyncFunction = obj => obj[Symbol.toStringTag] === 'AsyncFunction';
+const generateRandomString = () =>
+  Math.random()
+    .toString(36)
+    .substring(2, 15) +
+  Math.random()
+    .toString(36)
+    .substring(2, 15);
+
+/**
+ * @async
+ * @param {import('puppeteer').Browser} browser
+ * @param {(Step)[]} steps
+ * @returns {object[]}
+ */
+export default async function autoParse(browser, steps) {
+  const page = await browser.newPage();
+
+  let index = 0;
+
+  /**
+   * Process a single step
+   * @param {Step} step
+   * @param {object} state state object
+   * @param {object} iteratee argument to pass to the function
+   * @returns {State} mutated state
+   */
+  async function handleStep(step, state, iteratee = null) {
+    console.log('Step', JSON.stringify(step));
+    const {
+      id = index.toString(),
+      type,
+      selector,
+      timeout = 5000,
+      childSteps,
+      collectionId,
+      func,
+      url,
+    } = step;
+
+    const iteratorResults = [];
+
+    switch (type) {
+      case 'navigate':
+        switch (true) {
+          case isString(url):
+            await page.goto(url);
+            break;
+          case isFunction(url):
+            await page.goto(url(state, iteratee));
+            break;
+          default:
+            console.error('Unexpected url key value:', url);
+            break;
+        }
+        break;
+      case 'elementClick':
+        if (selector) {
+          await page.click(selector);
+        } else {
+          await iteratee.click();
+        }
+        break;
+      case 'elementWait':
+        await page.waitForSelector(selector, {visible: true, timeout});
+        break;
+      case 'elementsQuery':
+        return Object.assign(state, {
+          [id]: await page.$$(selector),
+        });
+      case 'evaluatePage':
+        return Object.assign(state, {
+          [id]: await page.evaluate(func, iteratee),
+        });
+      case 'iterator':
+        if (!(collectionId in state)) {
+          throw new Error(
+            `The collectionId you specified does not exist in the state: '${collectionId}'`
+          );
+        }
+        for (const item of state[collectionId]) {
+          let tempState = {};
+          for (const childStep of childSteps) {
+            tempState = await handleStep(childStep, tempState, item);
+          }
+          iteratorResults.push(tempState);
+        }
+        return Object.assign(state, {
+          [id]: iteratorResults,
+        });
+      case 'mutateState':
+        return Object.assign(state, await func(state));
+      default:
+        console.error('Unknown step type', type);
+        break;
+    }
+    return state;
+  }
+
+  let rootState = {};
+
+  for (const step of steps) {
+    rootState = await handleStep(step, rootState);
+    index += 1;
+  }
+  await page.close();
+
+  return rootState;
+}

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -29,7 +29,7 @@
  * evaluate
  * @property {EvaluateFunction} [evaluateFunc]
  *
- * mutateState
+ * mutateResult
  * @property {EvaluateFunction} [mutateFunc]
  *
  * iterator

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -134,14 +134,16 @@ export default async function autoParse(browser, steps) {
           switch (true) {
             case isString(value):
               elementQueryShapeResult[key] = await page.evaluate(
-                (elem, sel) => elem.querySelector(sel).textContent.trim(),
+                (elem, sel) =>
+                  elem.querySelector(sel) ? elem.querySelector(sel).textContent.trim() : null,
                 iteratee || page,
                 value
               );
               break;
             case Array.isArray(value):
               elementQueryShapeResult[key] = await page.evaluate(
-                (elem, sel) => elem.querySelector(sel).textContent.trim(),
+                (elem, sel) =>
+                  elem.querySelector(sel) ? elem.querySelector(sel).textContent.trim() : null,
                 iteratee || page,
                 value[0]
               );

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -180,7 +180,12 @@ export default async function autoParse(browser, steps) {
   let result = null;
 
   for (const step of steps) {
-    result = await handleStep(step, result);
+    try {
+      result = await handleStep(step, result);
+    } catch (e) {
+      console.error('Last result before exception:', result);
+      throw e;
+    }
   }
   await page.close();
 

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -40,6 +40,9 @@
  * @property {Step} [parent] parent step
  * @property {string} collectionId key to an collection in the state object
  *
+ * elementsQuery
+ * @property {boolean} [ignoreIteratee] whether to ignore the iteratee to query
+ *
  * elementQueryShape
  * @property {Object.<string, string>|[Object.<string, string>, QueryShapeProcessFunction]} [queryShape]
  */
@@ -86,6 +89,7 @@ export default async function autoParse(browser, steps) {
       mutateFunc,
       url,
       queryShape,
+      ignoreIteratee,
     } = step;
 
     const iteratorResults = [];
@@ -126,7 +130,7 @@ export default async function autoParse(browser, steps) {
         break;
       case 'elementsQuery':
         return Object.assign(state, {
-          [id]: await (iteratee || page).$$(selector),
+          [id]: await ((!ignoreIteratee && iteratee) || page).$$(selector),
         });
       case 'elementQueryShape':
         for (const key of Object.keys(queryShape)) {

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -38,7 +38,7 @@
  * @property {Step} [parent] parent step
  *
  * elementsQuery
- * @property {boolean} [ignoreIteratee] whether to ignore the iteratee to query
+ * @property {('iteratee'|'document')} [querySource] whether to ignore the iteratee to query
  *
  * elementQueryShape
  * @property {Object.<string, string>|[Object.<string, string>, QueryShapeProcessFunction]} [queryShape]
@@ -83,7 +83,7 @@ export default async function autoParse(browser, steps) {
       mutateFunc,
       url,
       queryShape,
-      ignoreIteratee,
+      querySource,
     } = step;
 
     const iteratorResults = [];
@@ -124,9 +124,9 @@ export default async function autoParse(browser, steps) {
         break;
       case 'elementsQuery':
         if (selectorType === 'xpath') {
-          return ((!ignoreIteratee && iteratee) || page).$x(selector);
+          return ((querySource === 'iteratee' && iteratee) || page).$x(selector);
         }
-        return ((!ignoreIteratee && iteratee) || page).$$(selector);
+        return ((querySource === 'iteratee' && iteratee) || page).$$(selector);
       case 'elementQueryShape':
         for (const key of Object.keys(queryShape)) {
           const value = queryShape[key];
@@ -137,7 +137,7 @@ export default async function autoParse(browser, steps) {
                   (elem || document).querySelector(sel)
                     ? (elem || document).querySelector(sel).textContent.trim()
                     : null,
-                !ignoreIteratee && iteratee,
+                querySource === 'iteratee' && iteratee,
                 value
               );
               break;
@@ -147,7 +147,7 @@ export default async function autoParse(browser, steps) {
                   (elem || document).querySelector(sel)
                     ? (elem || document).querySelector(sel).textContent.trim()
                     : null,
-                !ignoreIteratee && iteratee,
+                querySource === 'iteratee' && iteratee,
                 value[0]
               );
               elementQueryShapeResult[key] = value[1](elementQueryShapeResult[key]);

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -19,7 +19,7 @@
  * @typedef Step
  * @property {('navigate'|'elementClick'|'elementWait'|'elementsQuery'|'elementQueryShape'|'elementScrollIntoView'|'iterator'|'evaluatePage'|'mutateResult')} type
  * @property {string|IteratorTargetFunction} selector DOM selector
- * @property {boolean} isXPathSelector whether the selector is an XPath expression
+ * @property {('css'|'xpath')} selectorType type of the selector
  *
  * elementWait
  * @property {number} [timeout] timeout for wait
@@ -76,7 +76,7 @@ export default async function autoParse(browser, steps) {
     const {
       type,
       selector,
-      isXPathSelector = false,
+      selectorType = 'css',
       timeout = 5000,
       childSteps,
       evaluateFunc,
@@ -123,7 +123,7 @@ export default async function autoParse(browser, steps) {
         }, selector || iteratee);
         break;
       case 'elementsQuery':
-        if (isXPathSelector) {
+        if (selectorType === 'xpath') {
           return ((!ignoreIteratee && iteratee) || page).$x(selector);
         }
         return ((!ignoreIteratee && iteratee) || page).$$(selector);

--- a/src/util/auto-parse.js
+++ b/src/util/auto-parse.js
@@ -19,6 +19,7 @@
  * @typedef Step
  * @property {('navigate'|'elementClick'|'elementWait'|'elementsQuery'|'elementQueryShape'|'elementScrollIntoView'|'iterator'|'evaluatePage'|'mutateResult')} type
  * @property {string|IteratorTargetFunction} selector DOM selector
+ * @property {boolean} isXPathSelector whether the selector is an XPath expression
  *
  * elementWait
  * @property {number} [timeout] timeout for wait
@@ -75,6 +76,7 @@ export default async function autoParse(browser, steps) {
     const {
       type,
       selector,
+      isXPathSelector = false,
       timeout = 5000,
       childSteps,
       evaluateFunc,
@@ -121,6 +123,9 @@ export default async function autoParse(browser, steps) {
         }, selector || iteratee);
         break;
       case 'elementsQuery':
+        if (isXPathSelector) {
+          return ((!ignoreIteratee && iteratee) || page).$x(selector);
+        }
         return ((!ignoreIteratee && iteratee) || page).$$(selector);
       case 'elementQueryShape':
         for (const key of Object.keys(queryShape)) {


### PR DESCRIPTION
# Purpose
This PR adds support for auto-parse, which is a way to write scraping instructions in a declarative manner.

This allows us to write scraping code in this manner:
```js
await autoParse(browser, [
  {
    type: 'navigate',
    url: 'https://www.koithe.com/en/global/koi-singapore',
  },
  {
    type: 'elementsQuery',
    selector: '.global-wrap .item',
  },
  {
    type: 'iterator',
    childSteps: [
      {
        type: 'elementQueryShape',
        queryShape: {
          title: '.titlebox',
          address: '.txt a',
          phone: '.titlebox',
          openingHours: '.txt',
        },
      },
    ],
  },
]);
```